### PR TITLE
Added bodyEncoding support, multiple cookies in one Set-cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ HTTP get, body as parsed json
 dynamic body = await Requests.get("https://mydomain.com/api/v1/foo", json: true);
 ```
 
-HTTP post, body is json, result is json
+HTTP post, body is map or a list (being sent as application/x-www-form-urlencoded, until stated otherwise in `bodyEncoding` parameter), result is json
 
 ```dart
 dynamic body = await Requests.post("https://mydomain.com/api/v1/foo", json: true, body: {"foo":"bar"} );

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -84,7 +84,7 @@ class Requests {
     dynamic parseException;
 
     try {
-      responseBody = utf8.decode(response.bodyBytes);
+      responseBody = utf8.decode(response.bodyBytes, allowMalformed: true);
     } catch (e) {
       parseException = e;
     }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -28,7 +28,9 @@ class Requests {
     for (var key in responseHeaders.keys) {
       if (Common.equalsIgnoreCase(key, 'set-cookie')) {
         String cookie = responseHeaders[key];
-        cookie.split(";").map((x) => x.trim().split("=")).where((x) => x.length == 2).where((x) => !_cookiesKeysToIgnore.contains(x[0])).forEach((x) => cookies[x[0]] = x[1]);
+        cookie.split(",").forEach((String one) {
+          cookie.split(";").map((x) => x.trim().split("=")).where((x) => x.length == 2).where((x) => !_cookiesKeysToIgnore.contains(x[0])).forEach((x) => cookies[x[0]] = x[1]);
+        });
         break;
       }
     }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -7,6 +7,11 @@ import 'dart:core';
 import 'common.dart';
 import 'event.dart';
 
+enum RequestBodyEncoding {
+  JSON,
+  FormURLEncoded
+}
+
 final Logger log = new Logger('requests');
 
 class Requests {
@@ -116,31 +121,31 @@ class Requests {
     return responseBody;
   }
 
-  static Future<dynamic> head(String url, {headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_HEAD, url, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> head(String url, {headers, bodyEncoding, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_HEAD, url, bodyEncoding: bodyEncoding, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> get(String url, {headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_GET, url, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> get(String url, {headers, bodyEncoding, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_GET, url, bodyEncoding: bodyEncoding, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> patch(String url, {headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_PATCH, url, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> patch(String url, {headers, bodyEncoding, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_PATCH, url, bodyEncoding: bodyEncoding, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> delete(String url, {headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_DELETE, url, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> delete(String url, {headers, bodyEncoding, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_DELETE, url, bodyEncoding: bodyEncoding, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> post(String url, {body, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_POST, url, body: body, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> post(String url, {body, bodyEncoding, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_POST, url, bodyEncoding: bodyEncoding, body: body, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> put(String url, {body, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
-    return _httpRequest(HTTP_METHOD_PUT, url, body: body, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
+  static Future<dynamic> put(String url, {body, bodyEncoding, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) {
+    return _httpRequest(HTTP_METHOD_PUT, url, bodyEncoding: bodyEncoding, body: body, headers: headers, timeoutSeconds: timeoutSeconds, json: json, persistCookies: persistCookies);
   }
 
-  static Future<dynamic> _httpRequest(String method, String url, {body, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) async {
+  static Future<dynamic> _httpRequest(String method, String url, {body, bodyEncoding = RequestBodyEncoding.FormURLEncoded, headers, timeoutSeconds = DEFAULT_TIMEOUT_SECONDS, json = false, persistCookies = true}) async {
     var client = http.Client();
     var uri = Uri.parse(url);
     String hostname = uri.host;
@@ -154,7 +159,15 @@ class Requests {
         contentTypeHeader = "text/plain";
       } else if (body is Map || body is List) {
         bodyString = Common.toJson(body);
-        contentTypeHeader = "application/json";
+
+        if (bodyEncoding == RequestBodyEncoding.JSON) {
+          contentTypeHeader = "application/json";
+        } else if(bodyEncoding == RequestBodyEncoding.FormURLEncoded) {
+          contentTypeHeader = "application/x-www-form-urlencoded";
+        }
+
+        // BC Break
+        // contentTypeHeader = "application/json";
       }
 
       if (contentTypeHeader != null && !Common.hasKeyIgnoreCase(headers, "content-type")) {

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -1,4 +1,5 @@
 import 'package:requests/requests.dart';
+import 'package:requests/src/common.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
 
@@ -20,12 +21,22 @@ void main() {
     });
 
     test('json http post', () async {
-      await Requests.post("https://jsonplaceholder.typicode.com/posts", body: {
+      var body = await Requests.post("https://jsonplaceholder.typicode.com/posts", body: {
         "userId": 10,
         "id": 91,
         "title": "aut amet sed",
         "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
-      });
+      }, bodyEncoding: RequestBodyEncoding.FormURLEncoded);
+      expect(body, isNotNull);
+    });
+    test('json http post as a form and as a JSON', () async {
+      var res = await Requests.post("https://jsonplaceholder.typicode.com/posts", body: {
+        "userId": 10,
+        "id": 91,
+        "title": "aut amet sed",
+        "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+      }, bodyEncoding: RequestBodyEncoding.JSON, json: true);
+      expect(res["userId"], 10);
     });
 
     test('json http get object', () async {


### PR DESCRIPTION
Based on issue I added, https://github.com/jossef/requests/issues/4

bodyEncoding support added, defaulting to FormURLEncoded

Also enabled allowMalformed for utf8.decode because the basic test to google.com was failing because of malformed characters (probably Japanese)

Also added a comma separated list of cookies as they can be delimited by comma.