### PR TITLE
Error Object, remove unnecessary `new` keywords, format code

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -21,7 +21,7 @@ class Common {
   }
 
   static String toJson(dynamic object) {
-    var encoder = new JsonEncoder.withIndent("     ");
+    var encoder = JsonEncoder.withIndent("     ");
     return encoder.convert(object);
   }
 

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -4,7 +4,7 @@ class Event {
   StreamController<dynamic> _streamController;
 
   Event() {
-    this._streamController = new StreamController<dynamic>.broadcast(sync: true);
+    this._streamController = StreamController<dynamic>.broadcast(sync: true);
   }
 
   Stream<dynamic> _getStream() {

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('A group of tests', () {
+    const PLACEHOLDER_PROVIDER = 'https://reqres.in';
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
@@ -14,40 +15,49 @@ void main() {
     });
 
     test('json http get list of objects', () async {
-      dynamic body = await Requests.get("https://jsonplaceholder.typicode.com/posts", json: true);
+      dynamic body =
+          await Requests.get("$PLACEHOLDER_PROVIDER/api/users", json: true);
       expect(body, isNotNull);
-      expect(body, isList);
+      expect(body['data'], isList);
     });
 
     test('json http post', () async {
-      var body = await Requests.post("https://jsonplaceholder.typicode.com/posts", body: {
-        "userId": 10,
-        "id": 91,
-        "title": "aut amet sed",
-        "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
-      }, bodyEncoding: RequestBodyEncoding.FormURLEncoded);
+      var body = await Requests.post("$PLACEHOLDER_PROVIDER/api/users",
+          body: {
+            "userId": 10,
+            "id": 91,
+            "title": "aut amet sed",
+            "body":
+                "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+          },
+          bodyEncoding: RequestBodyEncoding.FormURLEncoded);
       expect(body, isNotNull);
     });
     test('json http post as a form and as a JSON', () async {
-      var res = await Requests.post("https://jsonplaceholder.typicode.com/posts", body: {
-        "userId": 10,
-        "id": 91,
-        "title": "aut amet sed",
-        "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
-      }, bodyEncoding: RequestBodyEncoding.JSON, json: true);
+      var res = await Requests.post("$PLACEHOLDER_PROVIDER/api/users",
+          body: {
+            "userId": 10,
+            "id": 91,
+            "title": "aut amet sed",
+            "body":
+                "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+          },
+          bodyEncoding: RequestBodyEncoding.JSON,
+          json: true);
       expect(res["userId"], 10);
     });
 
     test('json http get object', () async {
-      dynamic body = await Requests.get("https://jsonplaceholder.typicode.com/posts/1", json: true);
+      dynamic body =
+          await Requests.get("$PLACEHOLDER_PROVIDER/api/users/2", json: true);
       expect(body, isNotNull);
       expect(body, isMap);
     });
 
     test('remove cookies', () async {
-      String url = "https://jsonplaceholder.typicode.com/posts/1";
+      String url = "$PLACEHOLDER_PROVIDER/api/users/1";
       String hostname = Requests.getHostname(url);
-      expect("jsonplaceholder.typicode.com", hostname);
+      expect("reqres.in", hostname);
       await Requests.clearStoredCookies(hostname);
       await Requests.setStoredCookies(hostname, {'session': 'bla'});
       var cookies = await Requests.getStoredCookies(hostname);
@@ -55,6 +65,26 @@ void main() {
       await Requests.clearStoredCookies(hostname);
       cookies = await Requests.getStoredCookies(hostname);
       expect(cookies.keys.length, 0);
+    });
+
+    test('response as Response object', () async {
+      dynamic response = await Requests.post('$PLACEHOLDER_PROVIDER/api/users',
+          body: {"name": "morpheus"}, json: true, dataOnly: false);
+      expect(response.ok, isA<bool>());
+      expect(response.data, isNotNull);
+      expect(response.code, isA<int>());
+    });
+
+    test('throw error', () async {
+      try {
+        await Requests.get('$PLACEHOLDER_PROVIDER/api/unknown/23',
+            shouldThrow: true);
+      } catch (resp) {
+        expect(resp, isA<Response>());
+        expect(resp.ok, false);
+        return;
+      }
+      throw Exception('Expected request error');
     });
   });
 }


### PR DESCRIPTION
This commit adresses Issue #9 .
I've changed the json dummy provider to https://reqres.in/
Removed unnecessary `new` keyword: [Don't use new](https://dart.dev/guides/language/effective-dart/usage#dont-use-new)
Formatting code with dartfmt

Added:
 - shouldThrow: `bool` → Default: `true` (whether the request should throw an error with the `Request` object, the default is `true` to keep minimum compatibility)
 - dataOnly: `bool` → Default: `true` (whether the request should return only the response and not the `Request` object, the default is `true` to keep minimum compatibility)