### PR TITLE
added functionality to send delete Requests with a RequestBody

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -300,7 +300,7 @@ class Requests {
 
     String hostname = getHostname(url);
     headers = await _constructRequestHeaders(hostname, headers);
-    dynamic requestBody;
+    String requestBody;
 
     if (body != null && json != null) {
       throw ArgumentError('cannot use both "json" and "body" choose only one.');
@@ -343,7 +343,11 @@ class Requests {
         future = client.put(uri, body: requestBody, headers: headers);
         break;
       case HTTP_METHOD_DELETE:
-        future = client.delete(uri, headers: headers);
+        
+        final request = http.Request("DELETE", uri);
+        requestBody != null ? request.body = requestBody : null;
+        request.headers.addAll(headers);
+        future = client.send(request);
         break;
       case HTTP_METHOD_POST:
         future = client.post(uri, body: requestBody, headers: headers);
@@ -359,6 +363,9 @@ class Requests {
     }
 
     var response = await future.timeout(Duration(seconds: timeoutSeconds));
+    if(response is http.StreamedResponse){
+      response = await http.Response.fromStream(response);  
+    }
     return await _handleHttpResponse(hostname, response, persistCookies);
   }
 }

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -62,7 +62,7 @@ void main() {
     });
 
     test('json http delete with request body', () async {
-      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", body: {"something":"something"}, headers: {"Content-Type": "application/json"},);
+      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", json: {"something":"something"},);
       // I didnt know a better way to test it, since I dont know your mock api...
       expect(r, isA<Response>());
     });

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -61,6 +61,12 @@ void main() {
       r.raiseForStatus();
     });
 
+    test('json http delete with request body', () async {
+      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", body: {"something":"something"}, headers: {"Content-Type": "application/json"},);
+      // I didnt know a better way to test it, since I dont know your mock api...
+      expect(r, isA<Response>());
+    });
+
     test('json http post as a form and as a JSON', () async {
       var r = await Requests.post("$PLACEHOLDER_PROVIDER/api/users",
           json: {


### PR DESCRIPTION
I repaced the normal http.Client.delete call with the http.Client.send and constructed the http.Request myself to enable the sending of a RequestBody.