### PR TITLE
apply ignore case for servers return lower case cookies

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -74,13 +74,13 @@ class Requests {
       RequestBodyEncoding.FormURLEncoded;
 
   static Set _cookiesKeysToIgnore = Set.from([
-    "SameSite",
-    "Path",
-    "Domain",
-    "Max-Age",
-    "Expires",
-    "Secure",
-    "HttpOnly"
+    "samesite",
+    "path",
+    "domain",
+    "max-age",
+    "expires",
+    "secure",
+    "httponly"
   ]);
 
   static Map<String, String> _extractResponseCookies(responseHeaders) {
@@ -89,11 +89,11 @@ class Requests {
       if (Common.equalsIgnoreCase(key, 'set-cookie')) {
         String cookie = responseHeaders[key];
         cookie.split(",").forEach((String one) {
-          cookie
+          one
               .split(";")
               .map((x) => x.trim().split("="))
               .where((x) => x.length == 2)
-              .where((x) => !_cookiesKeysToIgnore.contains(x[0]))
+              .where((x) => !_cookiesKeysToIgnore.contains(x[0].toLowerCase()))
               .forEach((x) => cookies[x[0]] = x[1]);
         });
         break;


### PR DESCRIPTION
Fixes #23 
Some servers return "expires, domain and path" cookies in lower case. converting set `_cookiesKeysToIgnore ` to lower case and apply `toLowerCase()` method while checking the set is containing the cookie key will solve the issue.
