### PR TITLE
Added queryParameters support and moved port to Uri.

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,5 +9,9 @@ jobs:
     steps:
       - name: Running analyze
         run: flutter analyze .
+        with:
+          flutter_package: true
       - name: Running tests
         run: flutter test .
+        with:
+          flutter_package: true

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1.2.0
         with:
-          flutter-version: '1.12.3'
+          flutter-version: '1.11.0'
           channel: 'beta'
       - run: flutter pub get
       - run: flutter test .

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v1.2.0
         with:
           flutter-version: '1.12.3'
           channel: 'beta'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,14 +4,20 @@ on: [push]
 
 jobs:
   quality-assurance:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Running analyze
-        run: flutter analyze .
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
         with:
-          flutter_package: true
-      - name: Running tests
-        run: flutter test .
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
         with:
-          flutter_package: true
+          flutter-version: '1.12.3'
+          channel: 'beta'
+      - run: flutter pub get
+      - run: flutter test .
+      - run: flutter analyze .

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,13 @@
+name: Quality Assurance
+
+on: [push]
+
+jobs:
+  quality-assurance:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Running analyze
+        run: flutter analyze .
+      - name: Running tests
+        run: flutter test .

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   quality-assurance:
-    name: Test on ${{ matrix.os }}
+    name: QA on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ version
 **/doc/api/
 .dart_tool/
 .flutter-plugins
+.flutter-plugins-dependencies
 .packages
 .pub-cache/
 .pub/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,14 @@
 ## 3.0.5
 
 - fix: added body in patch and delete methods 
+
+## 3.1.0
+
+- BREAKING CHANGE: removed port from url. Added parameter port according to `Uri` best practices.
+- feature: added queryParameter support in get requests
+- feature: created Github QA workflow to prevent pushes that breaks analyze or tests
+- enhancement: changed http method strings into enum to avoid errors
+- enhancement: improved type of arguments to prevent unexpected errors
+- enhancement: added more validations on tests
+- enhancement: executed flutter format to improve pub score
+- enhancement: changed some anti patterns.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,5 +10,5 @@ include: package:pedantic/analysis_options.yaml
 #     - camel_case_types
 
 analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+   exclude:
+     - test/**

--- a/lib/requests.dart
+++ b/lib/requests.dart
@@ -1,2 +1,3 @@
 library requests;
+
 export 'src/requests.dart';

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -277,9 +277,6 @@ class Requests {
       int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
       bool persistCookies = true,
       bool verify = true}) async {
-    assert(!(body != null && json != null),
-        'cannot use both "json" and "body" choose only one.');
-
     http.Client client;
     if (!verify) {
       // Ignore SSL errors
@@ -293,14 +290,18 @@ class Requests {
 
     var uri = Uri.parse(url);
 
-    assert(
-        !(uri.scheme != 'http' && uri.scheme != 'https'),
-        ArgumentError(
-            "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')"));
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      throw ArgumentError(
+          "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')");
+    }
 
     String hostname = getHostname(url);
     headers = await _constructRequestHeaders(hostname, headers);
     String requestBody;
+
+    if (body != null && json != null) {
+      throw ArgumentError('cannot use both "json" and "body" choose only one.');
+    }
 
     if (queryParameters != null) {
       uri.replace(queryParameters: queryParameters);

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -216,6 +216,8 @@ class Requests {
 
   static Future<Response> delete(String url,
       {Map<String, String> headers,
+      Map<String, dynamic> json,
+      dynamic body,
       int port,
       RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
       int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
@@ -224,6 +226,8 @@ class Requests {
     return _httpRequest(HttpMethod.DELETE, url,
         bodyEncoding: bodyEncoding,
         port: port,
+        json: json,
+        body: body,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
         persistCookies: persistCookies,
@@ -358,7 +362,14 @@ class Requests {
         future = client.put(uri, body: requestBody, headers: headers);
         break;
       case HttpMethod.DELETE:
-        future = client.delete(uri, headers: headers);
+        final request = http.Request("DELETE", uri);
+        request.headers.addAll(headers);
+
+        if (requestBody != null) {
+          request.body = requestBody;
+        }
+
+        future = client.send(request);
         break;
       case HttpMethod.POST:
         future = client.post(uri, body: requestBody, headers: headers);

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -180,6 +180,7 @@ class Requests {
 
   static Future<Response> get(String url,
       {Map<String, String> headers,
+      Map<String, dynamic> queryParameters,
       int port,
       RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
       int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
@@ -187,6 +188,7 @@ class Requests {
       bool verify = true}) {
     return _httpRequest(HttpMethod.GET, url,
         bodyEncoding: bodyEncoding,
+        queryParameters: queryParameters,
         port: port,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
@@ -217,6 +219,7 @@ class Requests {
   static Future<Response> delete(String url,
       {Map<String, String> headers,
       Map<String, dynamic> json,
+      Map<String, dynamic> queryParameters,
       dynamic body,
       int port,
       RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
@@ -225,6 +228,7 @@ class Requests {
       bool verify = true}) {
     return _httpRequest(HttpMethod.DELETE, url,
         bodyEncoding: bodyEncoding,
+        queryParameters: queryParameters,
         port: port,
         json: json,
         body: body,
@@ -316,11 +320,11 @@ class Requests {
     }
 
     if (queryParameters != null) {
-      uri.replace(queryParameters: queryParameters);
+      uri = uri.replace(queryParameters: queryParameters);
     }
 
     if (port != null) {
-      uri.replace(port: port);
+      uri = uri.replace(port: port);
     }
 
     if (json != null) {

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -163,13 +163,15 @@ class Requests {
   }
 
   static Future<Response> head(String url,
-      {headers,
-      bodyEncoding = DEFAULT_BODY_ENCODING,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) {
+      {Map<String, String> headers,
+      int port,
+      RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) {
     return _httpRequest(HttpMethod.HEAD, url,
         bodyEncoding: bodyEncoding,
+        port: port,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
         persistCookies: persistCookies,
@@ -177,13 +179,15 @@ class Requests {
   }
 
   static Future<Response> get(String url,
-      {headers,
-      bodyEncoding = DEFAULT_BODY_ENCODING,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) {
+      {Map<String, String> headers,
+      int port,
+      RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) {
     return _httpRequest(HttpMethod.GET, url,
         bodyEncoding: bodyEncoding,
+        port: port,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
         persistCookies: persistCookies,
@@ -191,15 +195,17 @@ class Requests {
   }
 
   static Future<Response> patch(String url,
-      {headers,
-      json,
-      body,
-      bodyEncoding = DEFAULT_BODY_ENCODING,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) {
+      {Map<String, String> headers,
+      int port,
+      Map<String, dynamic> json,
+      dynamic body,
+      RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) {
     return _httpRequest(HttpMethod.PATCH, url,
         bodyEncoding: bodyEncoding,
+        port: port,
         json: json,
         body: body,
         headers: headers,
@@ -209,17 +215,15 @@ class Requests {
   }
 
   static Future<Response> delete(String url,
-      {headers,
-      json,
-      body,
-      bodyEncoding = DEFAULT_BODY_ENCODING,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) {
+      {Map<String, String> headers,
+      int port,
+      RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) {
     return _httpRequest(HttpMethod.DELETE, url,
         bodyEncoding: bodyEncoding,
-        json: json,
-        body: body,
+        port: port,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
         persistCookies: persistCookies,
@@ -227,16 +231,18 @@ class Requests {
   }
 
   static Future<Response> post(String url,
-      {json,
-      body,
-      bodyEncoding = DEFAULT_BODY_ENCODING,
-      headers,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) {
+      {Map<String, dynamic> json,
+      int port,
+      dynamic body,
+      RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+      Map<String, String> headers,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) {
     return _httpRequest(HttpMethod.POST, url,
         bodyEncoding: bodyEncoding,
         json: json,
+        port: port,
         body: body,
         headers: headers,
         timeoutSeconds: timeoutSeconds,
@@ -246,17 +252,19 @@ class Requests {
 
   static Future<Response> put(
     String url, {
-    json,
-    body,
-    bodyEncoding = DEFAULT_BODY_ENCODING,
-    headers,
-    timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-    persistCookies = true,
-    verify = true,
+    int port,
+    Map<String, dynamic> json,
+    dynamic body,
+    RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
+    Map<String, String> headers,
+    int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+    bool persistCookies = true,
+    bool verify = true,
   }) {
     return _httpRequest(
       HttpMethod.PUT,
       url,
+      port: port,
       bodyEncoding: bodyEncoding,
       json: json,
       body: body,
@@ -350,10 +358,7 @@ class Requests {
         future = client.put(uri, body: requestBody, headers: headers);
         break;
       case HttpMethod.DELETE:
-        final request = http.Request("DELETE", uri);
-        requestBody != null ? request.body = requestBody : null;
-        request.headers.addAll(headers);
-        future = client.send(request);
+        future = client.delete(uri, headers: headers);
         break;
       case HttpMethod.POST:
         future = client.post(uri, body: requestBody, headers: headers);

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -271,13 +271,13 @@ class Requests {
       {json,
       body,
       RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
-      queryParameters,
-      port,
-      headers,
-      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
-      persistCookies = true,
-      verify = true}) async {
-    assert(body != null && json != null, 'cannot use both "json" and "body" choose only one.');
+      Map <String, dynamic> queryParameters,
+      int port,
+      Map <String, String> headers,
+      int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+      bool persistCookies = true,
+      bool verify = true}) async {
+    assert(!(body != null && json != null), 'cannot use both "json" and "body" choose only one.');
 
     http.Client client;
     if (!verify) {
@@ -292,10 +292,8 @@ class Requests {
 
     var uri = Uri.parse(url);
 
-    if (uri.scheme != 'http' && uri.scheme != 'https') {
-      throw ArgumentError(
-          "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')");
-    }
+    assert(!(uri.scheme != 'http' && uri.scheme != 'https'), ArgumentError(
+        "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')"));
 
     String hostname = getHostname(url);
     headers = await _constructRequestHeaders(hostname, headers);
@@ -348,7 +346,6 @@ class Requests {
         future = client.put(uri, body: requestBody, headers: headers);
         break;
       case HttpMethod.DELETE:
-        
         final request = http.Request("DELETE", uri);
         requestBody != null ? request.body = requestBody : null;
         request.headers.addAll(headers);
@@ -363,14 +360,14 @@ class Requests {
       case HttpMethod.PATCH:
         future = client.patch(uri, body: requestBody, headers: headers);
         break;
-      default:
-        throw Exception('unsupported http method "$method"');
     }
 
     var response = await future.timeout(Duration(seconds: timeoutSeconds));
+
     if(response is http.StreamedResponse){
       response = await http.Response.fromStream(response);  
     }
+    
     return await _handleHttpResponse(hostname, response, persistCookies);
   }
 }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -271,13 +271,14 @@ class Requests {
       {json,
       body,
       RequestBodyEncoding bodyEncoding = DEFAULT_BODY_ENCODING,
-      Map <String, dynamic> queryParameters,
+      Map<String, dynamic> queryParameters,
       int port,
-      Map <String, String> headers,
+      Map<String, String> headers,
       int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
       bool persistCookies = true,
       bool verify = true}) async {
-    assert(!(body != null && json != null), 'cannot use both "json" and "body" choose only one.');
+    assert(!(body != null && json != null),
+        'cannot use both "json" and "body" choose only one.');
 
     http.Client client;
     if (!verify) {
@@ -292,18 +293,20 @@ class Requests {
 
     var uri = Uri.parse(url);
 
-    assert(!(uri.scheme != 'http' && uri.scheme != 'https'), ArgumentError(
-        "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')"));
+    assert(
+        !(uri.scheme != 'http' && uri.scheme != 'https'),
+        ArgumentError(
+            "invalid url, must start with 'http://' or 'https://' sheme (e.g. 'http://example.com')"));
 
     String hostname = getHostname(url);
     headers = await _constructRequestHeaders(hostname, headers);
     String requestBody;
 
-    if(queryParameters != null) {
+    if (queryParameters != null) {
       uri.replace(queryParameters: queryParameters);
     }
 
-    if(port != null) {
+    if (port != null) {
       uri.replace(port: port);
     }
 
@@ -315,7 +318,7 @@ class Requests {
     if (body != null) {
       String contentTypeHeader;
 
-      switch (bodyEncoding){
+      switch (bodyEncoding) {
         case RequestBodyEncoding.JSON:
           requestBody = Common.toJson(body);
           contentTypeHeader = "application/json";
@@ -364,10 +367,10 @@ class Requests {
 
     var response = await future.timeout(Duration(seconds: timeoutSeconds));
 
-    if(response is http.StreamedResponse){
-      response = await http.Response.fromStream(response);  
+    if (response is http.StreamedResponse) {
+      response = await http.Response.fromStream(response);
     }
-    
+
     return await _handleHttpResponse(hostname, response, persistCookies);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: requests
 description: a flutter library that helps with http requests and stored cookies
-version: 3.0.5
+version: 3.1.0
 homepage: https://github.com/jossef/requests
 authors:
 - Jossef Harush <jossef12@gmail.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/jossef/requests
 authors:
 - Jossef Harush <jossef12@gmail.com>
 - Rick Stanley <rick-stanley@hotmail.com>
+- Rafael Carvalho Monteiro <rafael@qwkin.io>
 - Martin <https://github.com/genesiscz>
 - Frederik Pietzko <pietzkof@gmail.com>
 environment:

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -28,6 +28,7 @@ void main() {
       var r = await Requests.get("https://google.com", queryParameters: DEFAULT_QUERY_PARAMETER);
       dynamic body = r.content();
       expect(body, isNotNull);
+      expect(r.url.toString(), contains('?id=1'));
       _validateBasicWorkingRequest(r);
     });
 

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -32,7 +32,8 @@ void main() {
             "userId": 10,
             "id": 91,
             "title": "aut amet sed",
-            "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+            "body":
+                "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
           },
           bodyEncoding: RequestBodyEncoding.FormURLEncoded);
 
@@ -47,7 +48,8 @@ void main() {
         "userId": 10,
         "id": 91,
         "title": "aut amet sed",
-        "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+        "body":
+            "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
       });
 
       r.raiseForStatus();
@@ -62,19 +64,22 @@ void main() {
     });
 
     test('json http delete with request body', () async {
-      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", json: {"something":"something"},);
+      var r = await Requests.delete(
+        "$PLACEHOLDER_PROVIDER/api/users/10",
+        json: {"something": "something"},
+      );
       // I didnt know a better way to test it, since I dont know your mock api...
       r.raiseForStatus();
     });
 
     test('json http post as a form and as a JSON', () async {
-      var r = await Requests.post("$PLACEHOLDER_PROVIDER/api/users",
-          json: {
-            "userId": 10,
-            "id": 91,
-            "title": "aut amet sed",
-            "body": "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
-          });
+      var r = await Requests.post("$PLACEHOLDER_PROVIDER/api/users", json: {
+        "userId": 10,
+        "id": 91,
+        "title": "aut amet sed",
+        "body":
+            "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
+      });
       r.raiseForStatus();
 
       dynamic body = r.json();
@@ -104,7 +109,8 @@ void main() {
     });
 
     test('response as Response object', () async {
-      var r = await Requests.post('$PLACEHOLDER_PROVIDER/api/users', body: {"name": "morpheus"});
+      var r = await Requests.post('$PLACEHOLDER_PROVIDER/api/users',
+          body: {"name": "morpheus"});
       r.raiseForStatus();
       var content = r.content();
       var json = r.json();
@@ -129,7 +135,8 @@ void main() {
 
     test('throw if both json and body used', () async {
       try {
-        await Requests.post('$PLACEHOLDER_PROVIDER/api/unknown/23', body: {}, json: {});
+        await Requests.post('$PLACEHOLDER_PROVIDER/api/unknown/23',
+            body: {}, json: {});
       } on ArgumentError catch (e) {
         return;
       }

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -50,6 +50,14 @@ void main() {
       _validateBasicWorkingRequest(r);
     });
 
+    test('json http delete with request body', () async {
+      var r = await Requests.delete(
+        "$PLACEHOLDER_PROVIDER/api/users/10",
+        json: {"something": "something"},
+      );
+      _validateBasicWorkingRequest(r);
+    });
+
     test('json http post', () async {
       var r = await Requests.post("$PLACEHOLDER_PROVIDER/api/users", json: {
         "userId": 10,

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -163,7 +163,8 @@ void main() {
     });
 
     test('http test custom port', () async {
-      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", port: 8080);
+      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10",
+          port: 8080);
       r.raiseForStatus();
     });
   });

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -25,7 +25,8 @@ void main() {
     });
 
     test('plain http get with query parameters', () async {
-      var r = await Requests.get("https://google.com", queryParameters: DEFAULT_QUERY_PARAMETER);
+      var r = await Requests.get("https://google.com",
+          queryParameters: DEFAULT_QUERY_PARAMETER);
       dynamic body = r.content();
       expect(body, isNotNull);
       expect(r.url.toString(), contains('?id=1'));

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -2,6 +2,13 @@ import 'package:requests/requests.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import "package:test/test.dart";
 
+void _validateBasicWorkingRequest(Response r) {
+  expect(r.statusCode, isA<int>());
+  expect(r.hasError, isA<bool>());
+  expect(r.success, isA<bool>());
+  r.raiseForStatus();
+}
+
 void main() {
   group('A group of tests', () {
     const PLACEHOLDER_PROVIDER = 'https://reqres.in';
@@ -11,9 +18,9 @@ void main() {
 
     test('plain http get', () async {
       var r = await Requests.get("https://google.com");
-      r.raiseForStatus();
       dynamic body = r.content();
       expect(body, isNotNull);
+      _validateBasicWorkingRequest(r);
     });
 
     test('json http get list of objects', () async {
@@ -24,6 +31,7 @@ void main() {
 
       expect(body, isNotNull);
       expect(body['data'], isList);
+      _validateBasicWorkingRequest(r);
     });
 
     test('FormURLEncoded http post', () async {
@@ -37,10 +45,9 @@ void main() {
           },
           bodyEncoding: RequestBodyEncoding.FormURLEncoded);
 
-      r.raiseForStatus();
-
       dynamic body = r.json();
       expect(body, isNotNull);
+      _validateBasicWorkingRequest(r);
     });
 
     test('json http post', () async {
@@ -52,24 +59,14 @@ void main() {
             "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
       });
 
-      r.raiseForStatus();
-
       dynamic body = r.json();
       expect(body, isNotNull);
+      _validateBasicWorkingRequest(r);
     });
 
     test('json http delete', () async {
       var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10");
-      r.raiseForStatus();
-    });
-
-    test('json http delete with request body', () async {
-      var r = await Requests.delete(
-        "$PLACEHOLDER_PROVIDER/api/users/10",
-        json: {"something": "something"},
-      );
-      // I didnt know a better way to test it, since I dont know your mock api...
-      r.raiseForStatus();
+      _validateBasicWorkingRequest(r);
     });
 
     test('json http post as a form and as a JSON', () async {
@@ -80,19 +77,19 @@ void main() {
         "body":
             "libero voluptate eveniet aperiam sed\nsunt placeat suscipit molestias\nsimilique fugit nam natus\nexpedita consequatur consequatur dolores quia eos et placeat",
       });
-      r.raiseForStatus();
 
       dynamic body = r.json();
       expect(body["userId"], 10);
+      _validateBasicWorkingRequest(r);
     });
 
     test('json http get object', () async {
       var r = await Requests.get("$PLACEHOLDER_PROVIDER/api/users/2");
-      r.raiseForStatus();
 
       dynamic body = r.json();
       expect(body, isNotNull);
       expect(body, isMap);
+      _validateBasicWorkingRequest(r);
     });
 
     test('remove cookies', () async {
@@ -111,14 +108,12 @@ void main() {
     test('response as Response object', () async {
       var r = await Requests.post('$PLACEHOLDER_PROVIDER/api/users',
           body: {"name": "morpheus"});
-      r.raiseForStatus();
       var content = r.content();
       var json = r.json();
 
-      expect(r.success, isA<bool>());
+      _validateBasicWorkingRequest(r);
       expect(content, isNotNull);
       expect(json, isNotNull);
-      expect(r.statusCode, isA<int>());
     });
 
     test('throw error', () async {
@@ -160,7 +155,7 @@ void main() {
     });
 
     test('http test custom port', () async {
-      var r = await Requests.get('http://portquiz.net:8080/');
+      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10", port: 8080);
       r.raiseForStatus();
     });
   });

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -11,13 +11,28 @@ void _validateBasicWorkingRequest(Response r) {
 
 void main() {
   group('A group of tests', () {
-    const PLACEHOLDER_PROVIDER = 'https://reqres.in';
+    final String PLACEHOLDER_PROVIDER = 'https://reqres.in';
+    final Map<String, dynamic> DEFAULT_QUERY_PARAMETER = {'id': '1'};
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
 
     test('plain http get', () async {
       var r = await Requests.get("https://google.com");
+      dynamic body = r.content();
+      expect(body, isNotNull);
+      _validateBasicWorkingRequest(r);
+    });
+
+    test('plain http get with query parameters', () async {
+      var r = await Requests.get("https://google.com", queryParameters: DEFAULT_QUERY_PARAMETER);
+      dynamic body = r.content();
+      expect(body, isNotNull);
+      _validateBasicWorkingRequest(r);
+    });
+
+    test('plain http get with port 80', () async {
+      var r = await Requests.get("http://google.com", port: 80);
       dynamic body = r.content();
       expect(body, isNotNull);
       _validateBasicWorkingRequest(r);
@@ -159,12 +174,6 @@ void main() {
 
     test('ssl allow invalid', () async {
       var r = await Requests.get('https://expired.badssl.com/', verify: false);
-      r.raiseForStatus();
-    });
-
-    test('http test custom port', () async {
-      var r = await Requests.delete("$PLACEHOLDER_PROVIDER/api/users/10",
-          port: 8080);
       r.raiseForStatus();
     });
   });


### PR DESCRIPTION
## Proposal

*We need to enable support of queryParameters in GET requests. Since `http` packages already provides us, we just need to add it on our GET interface*

## What was done

- Added queryParameter support
- Moved port configuration to another method parameter. That way we can remove the port configuration from string url and set it directly on Uri.
- Created QA Github action to run tests and analyze in every push
- Some code enhancements

## CHANGELOG

Added on changelog:

```
## 3.1.0

- BREAKING CHANGE: removed port from url. Added parameter port according to `Uri` best practices.
- feature: added queryParameter support in get requests
- feature: created Github QA workflow to prevent pushes that breaks analyze or tests
- enhancement: changed http method strings into enum to avoid errors
- enhancement: improved type of arguments to prevent unexpected errors
- enhancement: added more validations on tests
- enhancement: executed flutter format to improve pub score
- enhancement: changed some anti patterns.
```
