### PR TITLE
Updated cookie extraction to account for cookies ending in ==

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -83,7 +83,7 @@ class Requests {
     for (var key in responseHeaders.keys) {
       if (Common.equalsIgnoreCase(key, 'set-cookie')) {
         String cookie = responseHeaders[key];
-        RegExp regExp = RegExp(r"([A-Za-z0-9_]*)=([A-Za-z0-9_=.]*)");
+        RegExp regExp = RegExp(r"([A-Za-z0-9_]*)=([A-Za-z0-9_=.-]*)");
         var matches = regExp.allMatches(cookie).toList();
         cookies[matches[0].group(1)] = matches[0].group(2);
         break;
@@ -100,7 +100,6 @@ class Requests {
         cookies.keys.map((key) => "$key=${cookies[key]}").join("; ");
     Map<String, String> requestHeaders = Map();
     requestHeaders['cookie'] = cookie;
-
     if (customHeaders != null) {
       requestHeaders.addAll(customHeaders);
     }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -83,14 +83,9 @@ class Requests {
     for (var key in responseHeaders.keys) {
       if (Common.equalsIgnoreCase(key, 'set-cookie')) {
         String cookie = responseHeaders[key];
-        cookie.split(",").forEach((String one) {
-          one
-              .split(";")
-              .map((x) => x.trim().split("="))
-              .where((x) => x.length == 2)
-              .where((x) => !_cookiesKeysToIgnore.contains(x[0].toLowerCase()))
-              .forEach((x) => cookies[x[0]] = x[1]);
-        });
+        RegExp regExp = RegExp(r"([A-Za-z0-9_]*)=([A-Za-z0-9_=.]*)");
+        var matches = regExp.allMatches(cookie).toList();
+        cookies[matches[0].group(1)] = matches[0].group(2);
         break;
       }
     }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -68,16 +68,6 @@ class Requests {
   static const RequestBodyEncoding DEFAULT_BODY_ENCODING =
       RequestBodyEncoding.FormURLEncoded;
 
-  static Set _cookiesKeysToIgnore = Set.from([
-    "samesite",
-    "path",
-    "domain",
-    "max-age",
-    "expires",
-    "secure",
-    "httponly"
-  ]);
-
   static Map<String, String> _extractResponseCookies(responseHeaders) {
     Map<String, String> cookies = {};
     for (var key in responseHeaders.keys) {
@@ -85,7 +75,10 @@ class Requests {
         String cookie = responseHeaders[key];
         RegExp regExp = RegExp(r"([A-Za-z0-9_]*)=([A-Za-z0-9_=.-]*)");
         var matches = regExp.allMatches(cookie).toList();
-        cookies[matches[0].group(1)] = matches[0].group(2);
+        if (matches.isNotEmpty) {
+          // specifically take first match only
+          cookies[matches[0].group(1)] = matches[0].group(2);
+        }
         break;
       }
     }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -28,6 +28,8 @@ class Response {
 
   get url => _rawResponse.request.url;
 
+  Map<String, String> get headers => _rawResponse.headers;
+
   throwForStatus() {
     if (!success) {
       throw HTTPException(


### PR DESCRIPTION
I came across a scenario for a valid cookie that caused the library not to save the cookie to use in the following requests.

I had an account with the following cookie. 

```
7b66c8cd7bfb0426234gt531751a825d=MTU4NTg4NjgxMnxEdi1oQkFFQ182SUFBUkFCRUFBQWVmLWlBQU1HYzNSeWFXNW5EQkVBRDJOMWNuSmxiblJmZFhObGNsOXBaQVoxYVc1ME5qUUdBZ0FGQm5OMGNtbHVad3dPQUF4c1lYTjBYM05sWlc1ZllYUUZhVzUwTmpRRUJnRDh2UTFzdUFaemRISnBibWNNRkFBU2JHRnpkRjl6WlhOemFXOXVYMk5vWldOckJXbHASedRFDkFZQV9MME5iTGc9fNXSrFs8vR4XsWh423uv4BHmLjIwxduVgu8C9N_ZyJMQ
```

And one with the following Cookie (take note of the last few characters)

```
7b66c8cd7bfb03847515c731751a825d=MTU4NTg4NjcyMXxEdi1oQkFFQ182SUFBUkFCRUFBQWVfLWlBQU1HYzNSeWFXNW5EQTRBREd4aGMzUmZjMlZsYmw5aGRBVnBiblEyTkFRR0FQeTlEV3dDQm5OMGNtbHVad3dVQUJKc1lYTjBYM05sYzNOcGIyNWZZMartRfcWRmFXNTBOalFFQmdEOHZRMXNBZ1p6ZEhKcGJtY01FUUFQWTNWeWNtVnVkRjkxYzJWeVgybGtCblZwYm5RMk5BWUVBUDRDNVE9PXxZDLOyriy_fKHL7IOtdjK31JDZQAEb22_F3cnf03iATA==
```

The first account logs in fine and the following requests are authenticated. The second account logs in fine and then every request after fails authentications. The cookie never saved to disk because you checked for the split on '=' to equal 2 which will fail in the case above. 

I implemented a basic regex instead to account for hashes padded with = . My Regex suck so feel free to modify.
