### PR TITLE
Update shared_preferences requirement to 0.5.11, which supports Windows

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 dependencies:
   http: ^0.12.0
-  shared_preferences: ^0.5.2
+  shared_preferences: ^0.5.11
   crypto: ^2.0.6
   hex: ^0.1.2
   logging: ^0.11.3+2


### PR DESCRIPTION
Older versions of shared_preferences will cause plugin exception.