### PR TITLE
Allow defining a custom cookie vault

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart' as io_client;
 import 'package:logging/logging.dart';
+import 'package:stash/stash_api.dart';
 
 import 'common.dart';
 import 'event.dart';
@@ -292,6 +293,12 @@ class Requests {
       verify: verify,
     );
   }
+
+  /// Defines the `stash` `Vault` used to store cookies.
+  /// Must be defined before storing or accessing cookies, otherwise
+  /// a default one will be created on first use.
+  static Vault<String> setCookieVault(Vault<String> vault) =>
+      Common.setCookieVault(vault);
 
   static Future<Response> _httpRequest(HttpMethod method, String url,
       {dynamic json,


### PR DESCRIPTION
First pass at being able to provide a custom `Vault<String>` to the `Requests` singleton. I was able to integrate this in my project to encrypt the vault using AES.

cc @sehnryr 

Closes #62 