### PR TITLE
fix & refactor: allow defining a custom cookie vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ r.raiseForStatus();
 String body = r.content();
 ```
 
+You can find an example of encrypted cookies [here](./example/encrypted_cookies.dart).
 
 ### the `Response` object
 just like in python's request module, the `Response` object has this functionality
@@ -63,6 +64,7 @@ just like in python's request module, the `Response` object has this functionali
  
  ### Class Methods
 
+- `.init(path, vaultName, encryptionCipher)` - initialize Requests with a custom cookie vault
 - `.getHostname(url)` - returns the hostname of the given url
 - `.clearStoredCookies(hostname)` - clears the stored cookies for the hostname
 - `.setStoredCookies(hostname, Map<String, String>)` - set the stored cookies for the hostname
@@ -121,5 +123,7 @@ await Requests.clearStoredCookies(hostname);
 cookies = await Requests.getStoredCookies(hostname);
 expect(cookies.keys.length, 0);
 ``` 
+
+More examples can be found in [example/](./example/).
 
 <a href="https://www.freepik.com/free-photos-vectors/business">Business vector created by freepik - www.freepik.com</a>

--- a/example/encrypted_cookies.dart
+++ b/example/encrypted_cookies.dart
@@ -1,0 +1,30 @@
+import 'package:hive/hive.dart';
+import 'package:requests/requests.dart';
+
+void main(List<String> args) async {
+  // Generate a secure encryption key.
+  final List<int> encryptionKey = Hive.generateSecureKey();
+
+  final HiveAesCipher encryptionCipher = HiveAesCipher(encryptionKey);
+
+  // Initialize [Requests] with a custom encrypted vault that will be stored
+  // in the working directory.
+  Requests.init(
+    path: '.',
+    vaultName: 'customvault',
+    encryptionCipher: encryptionCipher,
+  );
+
+  String url = 'https://github.com/';
+  String hostname = Requests.getHostname(url);
+
+  // Get the cookies from `github.com`.
+  Response response = await Requests.get(url);
+
+  // Do something with [response]...
+
+  var cookies = await Requests.getStoredCookies(hostname);
+  print(cookies);
+
+  // Play with [cookies]...
+}

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -113,7 +113,7 @@ class Common {
     );
   }
 
-  /// Defines the cookie vault for this process with the optional [path], 
+  /// Defines the cookie vault for this process with the optional [path],
   /// [vaultName] and [encryptionCipher] parameters.
   /// No-op if a cookie vault is already defined.
   static void setCookieVault({
@@ -123,12 +123,10 @@ class Common {
   }) {
     assert(vault == null, 'Cookie vault is already initialized');
 
-    if (vault != null) {
-      vault = createCookieVault(
-        path: path,
-        vaultName: vaultName,
-        encryptionCipher: encryptionCipher,
-      );
-    }
+    vault ??= createCookieVault(
+      path: path,
+      vaultName: vaultName,
+      encryptionCipher: encryptionCipher,
+    );
   }
 }

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -9,8 +9,9 @@ import 'package:crypto/crypto.dart';
 class Common {
   const Common();
 
-  // The vault containing the cookies. Can be initialized before usage using `setCookieVault`,
-  // otherwise it will be created using `createDefaultCookieVault`.
+  /// The vault containing the cookies. Can be initialized before usage using
+  /// [setCookieVault], otherwise it will be created
+  /// using [createDefaultCookieVault].
   static Vault<String>? vault;
 
   /// Add / Replace this [Vault] [value] for the specified [key].
@@ -90,7 +91,8 @@ class Common {
     return vault ?? (vault = createDefaultCookieVault());
   }
 
-  /// Creates a default, plain-text Hive store and vault in the system temporary directory.
+  /// Creates a default, plain-text Hive store and vault
+  /// in the system temporary directory.
   static Vault<String> createDefaultCookieVault() {
     final path = Directory.systemTemp.path;
     final store = newHiveDefaultVaultStore(path: path);

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -9,23 +9,16 @@ import 'package:crypto/crypto.dart';
 class Common {
   const Common();
 
-  // Temporary directory
-  static final path = Directory.systemTemp.path;
-
-  // Creates a store
-  static final store = newHiveDefaultVaultStore(path: path);
-
-  // Creates a vault from the previously created store
-  static final vault = store.vault<String>(
-    name: 'cookieVault',
-    eventListenerMode: EventListenerMode.synchronous,
-  );
+  // The vault containing the cookies. Can be initialized before usage using `setCookieVault`,
+  // otherwise it will be created using `createDefaultCookieVault`.
+  static Vault<String>? vault;
 
   /// Add / Replace this [Vault] [value] for the specified [key].
   ///
   /// * [key]: the key
   /// * [value]: the value
   static Future<void> storageSet(String key, String value) async {
+    final vault = getVault();
     await vault.put(key, value);
   }
 
@@ -35,6 +28,7 @@ class Common {
   ///
   /// Returns a [String]
   static Future<String?> storageGet(String key) async {
+    final vault = getVault();
     return await vault.get(key);
   }
 
@@ -44,6 +38,7 @@ class Common {
   ///
   /// Returns `true` if the removal of the mapping for the specified [key] was successful.
   static Future<bool> storageRemove(String key) async {
+    final vault = getVault();
     await vault.remove(key);
     return !await vault.containsKey(key);
   }
@@ -88,5 +83,25 @@ class Common {
       var v = Uri.encodeComponent(data[key].toString());
       return '$k=$v';
     }).join('&');
+  }
+
+  /// Gets or creates the cookie vault.
+  static Vault<String> getVault() {
+    return vault ?? (vault = createDefaultCookieVault());
+  }
+
+  /// Creates a default, plain-text Hive store and vault in the system temporary directory.
+  static Vault<String> createDefaultCookieVault() {
+    final path = Directory.systemTemp.path;
+    final store = newHiveDefaultVaultStore(path: path);
+    return store.vault<String>(
+        name: 'cookieVault', eventListenerMode: EventListenerMode.synchronous);
+  }
+
+  /// Defines the cookie vault for this process.
+  /// No-op if a cookie vault is already defined.
+  static Vault<String> setCookieVault(Vault<String> newVault) {
+    assert(vault == null, 'Cookie vault is already initialized');
+    return vault ?? (vault = newVault);
   }
 }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart' as io_client;
 import 'package:logging/logging.dart';
+import 'package:stash/stash_api.dart';
 
 import 'common.dart';
 import 'event.dart';
@@ -301,6 +302,12 @@ class Requests {
       verify: verify,
     );
   }
+
+  /// Defines the `stash` `Vault` used to store cookies.
+  /// Must be defined before storing or accessing cookies, otherwise
+  /// a default one will be created on first use.
+  static Vault<String> setCookieVault(Vault<String> vault) =>
+      Common.setCookieVault(vault);
 
   static Future<Response> _httpRequest(HttpMethod method, String url,
       {dynamic json,

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -2,10 +2,10 @@ import 'dart:convert';
 import 'dart:core';
 import 'dart:io';
 
+import 'package:hive/hive.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart' as io_client;
 import 'package:logging/logging.dart';
-import 'package:stash/stash_api.dart';
 
 import 'common.dart';
 import 'event.dart';
@@ -78,6 +78,22 @@ class Requests {
     'secure',
     'httponly'
   };
+
+  /// Initialize [Requests] with a custom [stash] [Vault] to store cookies.
+  ///
+  /// Must be defined before storing or accessing cookies, otherwise
+  /// a default one will be created on first use.
+  static void init({
+    final String? path,
+    final String? vaultName,
+    final HiveCipher? encryptionCipher,
+  }) {
+    Common.setCookieVault(
+      path: path,
+      vaultName: vaultName,
+      encryptionCipher: encryptionCipher,
+    );
+  }
 
   static Map<String, String> extractResponseCookies(responseHeaders) {
     var cookies = <String, String>{};
@@ -302,12 +318,6 @@ class Requests {
       verify: verify,
     );
   }
-
-  /// Defines the [stash] [Vault] used to store cookies.
-  /// Must be defined before storing or accessing cookies, otherwise
-  /// a default one will be created on first use.
-  static Vault<String> setCookieVault(Vault<String> vault) =>
-      Common.setCookieVault(vault);
 
   static Future<Response> _httpRequest(HttpMethod method, String url,
       {dynamic json,

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -303,7 +303,7 @@ class Requests {
     );
   }
 
-  /// Defines the `stash` `Vault` used to store cookies.
+  /// Defines the [stash] [Vault] used to store cookies.
   /// Must be defined before storing or accessing cookies, otherwise
   /// a default one will be created on first use.
   static Vault<String> setCookieVault(Vault<String> vault) =>


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Allow defining a custom cookie vault with an optional `HiveCipher` as the encryption cipher when initializing `Requests` with `init` method.

cc @aramperes

Closes #62.

## Type of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jossef/requests/blob/master/.github/CONTRIBUTING.md) doc
- [x] My code follows the [Dart coding convention](https://dart.dev/guides/language/effective-dart/style)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Replaces #63 since its author did not allow edits by the maintainers.