### PR TITLE
revert buggy web support d7f9e231bc0c8df212a0dc10f782bf03374d3613

### DIFF
--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -1,8 +1,8 @@
 import 'dart:core';
-import 'dart:io' if (dart.library.html) '';
+import 'dart:io';
 
 import 'package:http/http.dart';
-import 'package:http/io_client.dart' if (dart.library.html) '';
+import 'package:http/io_client.dart';
 
 import 'package:requests/src/common.dart';
 import 'package:requests/src/cookie.dart';


### PR DESCRIPTION
## Proposed changes
Fixes #71 
Removing conditions on import 'package:http/io_client.dart'; and import 'dart:io'; does not causes crash on flutter web.
Some tests with --platform chrome|firefox still failing but errors are caused by other stuff.

I did some tests running my changes in a real flutter web application and no error was thrown other than previous mentioned (only for web). See Further comments section for details.

This fix will allow users to use this library on flutter web although with limited functionalities.

## Type of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jossef/requests/blob/master/.github/CONTRIBUTING.md) doc
- [x] My code follows the [Dart coding convention](https://dart.dev/guides/language/effective-dart/style)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary documentation (if appropriate)

## Further comments

After running my changes on real flutter web application an XMLHttpRequest error was thrown, but I solved that by configuring properly my backend CORS configuration. This is the same error that occurs during tests with --platform chrome.
Unfortunately, verify: false for SSL validity verify still not working on web. This require some large implementation (maybe also in http library, I didn't analyzed that so much).  A new issue will have to be opened after merge.
