### PR TITLE
feat: deprecate `getHostname`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ just like in python's request module, the `Response` object has this functionali
  ### Class Methods
 
 - `.getHostname(url)` - returns the hostname of the given url
-- `.clearStoredCookies(hostname)` - clears the stored cookies for the hostname
-- `.setStoredCookies(hostname, CookieJar)` - set the stored cookies for the hostname
-- `.getStoredCookies(hostname)` - returns a CookieJar of the stored cookies for the hostname
-- `.addCookie(hostname, name, value)` - add a Cookie to the CookieJar associated to the hostname
+- `.clearStoredCookies(url)` - clears the stored cookies for the url
+- `.setStoredCookies(url, CookieJar)` - set the stored cookies for the url
+- `.getStoredCookies(url)` - returns a CookieJar of the stored cookies for the url
+- `.addCookie(url, name, value)` - add a Cookie to the CookieJar associated to the url
 
  
 ## Examples
@@ -112,21 +112,20 @@ Play with stored cookies
 
 ```dart
 String url = "https://example.com";
-String hostname = Requests.getHostname(url);
-await Requests.clearStoredCookies(hostname);
+await Requests.clearStoredCookies(url);
 
 // Set cookies using [CookieJar.parseCookiesString]
 var cookies = CookieJar.parseCookiesString("name=value");
-await Requests.setStoredCookies(hostname, cookies);
+await Requests.setStoredCookies(url, cookies);
 
 // Add single cookie using [CookieJar.parseCookiesString]
-var cookieJar = await Requests.getStoredCookies(hostname);
+var cookieJar = await Requests.getStoredCookies(url);
 cookieJar["name"] = Cookie("name", "value");
-await Requests.setStoredCookies(hostname, cookieJar);
+await Requests.setStoredCookies(url, cookieJar);
 
 // Add a single cookie using [Requests.addCookie]
 // Same as the above one but without exposing `cookies.dart`
-Requests.addCookie(hostname, "name", "value");
+Requests.addCookie(url, "name", "value");
 ```
 
 More examples can be found in [example/](./example/).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ just like in python's request module, the `Response` object has this functionali
  
  ### Class Methods
 
-- `.getHostname(url)` - returns the hostname of the given url
 - `.clearStoredCookies(url)` - clears the stored cookies for the url
 - `.setStoredCookies(url, CookieJar)` - set the stored cookies for the url
 - `.getStoredCookies(url)` - returns a CookieJar of the stored cookies for the url

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -80,4 +80,16 @@ class Common {
       return '$k=$v';
     }).join('&');
   }
+
+  /// Get the hostname of a [url].
+  static String getHostname(String url) {
+    var uri = Uri.parse(url);
+    // If the url is already a hostname, return it.
+    // Get the first part of the split in case the hostname
+    // contains a path.
+    if (uri.path.isNotEmpty && url.startsWith(uri.path)) {
+      return url.split(RegExp(r'[#?/]'))[0];
+    }
+    return uri.host.isNotEmpty ? uri.host : uri.scheme;
+  }
 }

--- a/lib/src/requests.dart
+++ b/lib/src/requests.dart
@@ -35,7 +35,7 @@ class Requests {
   /// Get the [CookieJar] for the given [url] hostname, or an empty
   /// [CookieJar] if the hostname is not in the cache.
   static Future<CookieJar> getStoredCookies(String url) async {
-    var hostname = getHostname(url);
+    var hostname = Common.getHostname(url);
     var hostnameHash = Common.hashStringSHA256(hostname);
     var cookies = await Common.storageGet('cookies-$hostnameHash');
 
@@ -44,7 +44,7 @@ class Requests {
 
   /// Associates the [url] hostname with the given [cookies] into the cache.
   static Future setStoredCookies(String url, CookieJar cookies) async {
-    var hostname = getHostname(url);
+    var hostname = Common.getHostname(url);
     var hostnameHash = Common.hashStringSHA256(hostname);
     await Common.storageSet('cookies-$hostnameHash', cookies);
   }
@@ -52,7 +52,7 @@ class Requests {
   /// Removes the [url] hostname and its associated value, if present,
   /// from the cache.
   static Future clearStoredCookies(String url) async {
-    var hostname = getHostname(url);
+    var hostname = Common.getHostname(url);
     var hostnameHash = Common.hashStringSHA256(hostname);
     await Common.storageRemove('cookies-$hostnameHash');
   }
@@ -65,9 +65,9 @@ class Requests {
     await setStoredCookies(url, cookieJar);
   }
 
+  @Deprecated("Do not use this method, it is not needed anymore.")
   static String getHostname(String url) {
-    var uri = Uri.parse(url);
-    return uri.host;
+    return Common.getHostname(url);
   }
 
   static Future<Response> head(String url,

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -143,8 +143,6 @@ void main() {
 
     test('remove cookies', () async {
       String url = '$PLACEHOLDER_PROVIDER/api/users/1';
-      String hostname = Requests.getHostname(url);
-      expect('reqres.in', hostname);
       await Requests.clearStoredCookies(url);
       var cookies = CookieJar.parseCookiesString("session=bla");
       await Requests.setStoredCookies(url, cookies);
@@ -287,6 +285,16 @@ void main() {
     test('from json', () async {
       expect(Common.fromJson('{"a":1}'), {"a": 1});
       expect(Common.fromJson(null), null);
+    });
+
+    test('Common.getHostname', () {
+      var url = PLACEHOLDER_PROVIDER;
+      var host = Common.getHostname(url);
+      expect(host, 'reqres.in');
+      expect(Common.getHostname(host), 'reqres.in');
+      expect(Common.getHostname('$host/?=test'), 'reqres.in');
+      expect(Common.getHostname('$host:/?=test'), 'reqres.in');
+      expect(Common.getHostname('$host:8080/?=test'), 'reqres.in');
     });
   });
 }

--- a/test/requests_test.dart
+++ b/test/requests_test.dart
@@ -145,29 +145,29 @@ void main() {
       String url = '$PLACEHOLDER_PROVIDER/api/users/1';
       String hostname = Requests.getHostname(url);
       expect('reqres.in', hostname);
-      await Requests.clearStoredCookies(hostname);
+      await Requests.clearStoredCookies(url);
       var cookies = CookieJar.parseCookiesString("session=bla");
-      await Requests.setStoredCookies(hostname, cookies);
-      cookies = await Requests.getStoredCookies(hostname);
+      await Requests.setStoredCookies(url, cookies);
+      cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 1);
-      await Requests.clearStoredCookies(hostname);
-      cookies = await Requests.getStoredCookies(hostname);
+      await Requests.clearStoredCookies(url);
+      cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 0);
     });
 
     test('add cookies', () async {
-      String hostname = 'example';
-      await Requests.addCookie(hostname, 'name', 'value');
-      var cookies = await Requests.getStoredCookies(hostname);
+      String url = 'http://example.com';
+      await Requests.addCookie(url, 'name', 'value');
+      var cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 1);
-      await Requests.addCookie(hostname, 'name', 'value');
-      cookies = await Requests.getStoredCookies(hostname);
+      await Requests.addCookie(url, 'name', 'value');
+      cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 1);
-      await Requests.addCookie(hostname, 'another name', 'value');
-      cookies = await Requests.getStoredCookies(hostname);
+      await Requests.addCookie(url, 'another name', 'value');
+      cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 2);
-      await Requests.clearStoredCookies(hostname);
-      cookies = await Requests.getStoredCookies(hostname);
+      await Requests.clearStoredCookies(url);
+      cookies = await Requests.getStoredCookies(url);
       expect(cookies.keys.length, 0);
     });
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Changed the hostname parameter of the cookie management methods by the corresponding url. This will allow a better readability and a better use of these methods.

```dart
var hostname = getHostname(url);
Requests.clearStoredCookies(hostname);
Requests.setStoredCookies(hostname, cookies);
Requests.getStoredCookies(hostname);
Requests.addCookie(hostname, name, value);
```
To:
```dart
Requests.clearStoredCookies(url);
Requests.setStoredCookies(url, cookies);
Requests.getStoredCookies(url);
Requests.addCookie(url, name, value);
```

This was discussed there https://github.com/jossef/requests/issues/76#issuecomment-1159074094 and to explain quickly here, `getHostname(url)` isn't really needed and complexify the use of the other methods unnecessarily.

## Type of changes

What types of changes does your code introduce?

*Put an `x` in the boxes that apply.*

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jossef/requests/blob/master/.github/CONTRIBUTING.md) doc
- [x] My code follows the [Dart coding convention](https://dart.dev/guides/language/effective-dart/style)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary documentation (if appropriate)

## Further comments

It would be nice to be able to pass either the url or the hostname in the methods.